### PR TITLE
Update MouseBrain.celltypeslist.R for spelling

### DIFF
--- a/Mouse/Brain/MouseBrain.celltypeslist.R
+++ b/Mouse/Brain/MouseBrain.celltypeslist.R
@@ -11,7 +11,8 @@ celltypes = list(
             "Choroid plexus epithelial cells",
             "Hypendymal",
             "Neuroblasts",
-            "Tanycytes"
+            "Tanycytes",
+            "Ependymal cells"
         ),
         "Vascular" = list(
             "Pericytes",
@@ -31,7 +32,7 @@ celltypes = list(
             ),
             "Oligodendrocyte" = list(
                 "Committed oligodendrocytes",
-                "Myelin-forming oligodendrocytes",
+                "Myelin forming oligodendrocytes",
                 "Mature oligodendrocytes",
                 "Newly-formed oligodendrocytes",
                 "Oligodendrocyte precursor cells"
@@ -63,10 +64,11 @@ celltypes = list(
                     "Hindbrain excitatory neurons"
                 )
             ),
-            "Peptidergic neruons" = list(
+            "Peptidergic neurons" = list(
                 "Cholinergic neurons habenula",
                 "Dopaminergic neurons",
-                "Serotonergic neurons"
+                "Serotonergic neurons",
+                "Peptidergic neurons"
             ),
             "Inhibitory neuron" = list(
                 "Hindbrain inhibitory neurons",

--- a/Mouse/Brain/MouseBrain.celltypeslist.R
+++ b/Mouse/Brain/MouseBrain.celltypeslist.R
@@ -34,7 +34,7 @@ celltypes = list(
                 "Myelin-forming oligodendrocytes",
                 "Mature oligodendrocytes",
                 "Newly-formed oligodendrocytes",
-                "Oligodendrocytes precursor cells"
+                "Oligodendrocyte precursor cells"
             )
         ),
         "Neuron" = list(


### PR DESCRIPTION
Currently does not match with the mouseprofiles.csv title (Oligodendrocyte precursor cells vs oligodendrocytes precursor cells), gives matching errors.

When using the nested list after InSituType, the spelling differences leads to mismatches when searching for that specific string. 